### PR TITLE
Fix TypeError: BdApi.showConfirmationModal and use fetch for downloads

### DIFF
--- a/NitroEmoteAndScreenShareBypass.plugin.js
+++ b/NitroEmoteAndScreenShareBypass.plugin.js
@@ -47,32 +47,34 @@ module.exports = (() => {
 					return config.info.version;
 				}
 				load() {
-					BdApi.showConfirmationModal(
+					const showConfirmationModal = BdApi.UI?.showConfirmationModal || BdApi.showConfirmationModal;
+					if (!showConfirmationModal) return;
+					showConfirmationModal(
 						"Library Missing",
 						`The library plugin needed for ${config.info.name} is missing. Please click Download Now to install it.`,
 						{
 							confirmText: "Download Now",
 							cancelText: "Cancel",
-							onConfirm: () => {
-								require("request").get(
-									"https://rauenzi.github.io/BDPluginLibrary/release/0PluginLibrary.plugin.js",
-									async (error, response, body) => {
-										if (error)
-											return require("electron").shell.openExternal(
-												"https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js"
-											);
-										await new Promise((r) =>
-											require("fs").writeFile(
-												require("path").join(
-													BdApi.Plugins.folder,
-													"0PluginLibrary.plugin.js"
-												),
-												body,
-												r
-											)
-										);
-									}
-								);
+							onConfirm: async () => {
+								try {
+									const res = await fetch("https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js");
+									if (!res.ok) throw new Error("Failed to fetch");
+									const body = await res.text();
+									await new Promise((r) =>
+										require("fs").writeFile(
+											require("path").join(
+												BdApi.Plugins.folder,
+												"0PluginLibrary.plugin.js"
+											),
+											body,
+											r
+										)
+									);
+								} catch (error) {
+									require("electron").shell.openExternal(
+										"https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js"
+									);
+								}
 							},
 						}
 					);


### PR DESCRIPTION
## Description
This Pull Request resolves a crash/type error on startup in modern BetterDiscord environments and fixes the dependency download flow.

### 1. Fix `BdApi.showConfirmationModal` TypeError
- **Problem:** Modern BetterDiscord versions namespaces visual UI APIs under `BdApi.UI`. Calling `BdApi.showConfirmationModal` directly throws `TypeError: BdApi.showConfirmationModal is not a function`.
- **Solution:** Updated the loader to resolve `BdApi.UI.showConfirmationModal` first, falling back to `BdApi.showConfirmationModal` for backward compatibility.
- **Affected code:** `load()` method in `NitroEmoteAndScreenShareBypass.plugin.js`

### 2. Replace Deprecated `request` Dependency with Native `fetch`
- **Problem:** When the plugin detected a missing `ZeresPluginLibrary` dependency, clicking "Download Now" failed silently because the code relied on `require("request")`. The `request` package is deprecated and unavailable in modern Electron/BetterDiscord runtimes.
- **Solution:** Swapped `require("request").get` with the native, promise-based web `fetch()` API.
- **Affected code:** `onConfirm()` handler in the loader modal.

## How to Test
1. Remove `0PluginLibrary.plugin.js` from your BetterDiscord `plugins` folder.
2. Launch Discord/BetterDiscord.
3. The plugin will detect the missing library and display the **Library Missing** dialog (confirming `BdApi.UI.showConfirmationModal` works).
4. Click **Download Now**. The library will download successfully using `fetch()` and place the file in the plugins folder, enabling the plugin.
